### PR TITLE
Implement user registration, username availability check, and profile update logic in sBTC-dUser contract

### DIFF
--- a/contracts/sBTC-dUser.clar
+++ b/contracts/sBTC-dUser.clar
@@ -99,3 +99,94 @@
     (ok true)
   )
 )
+
+
+
+(define-public (register-user (username (string-ascii 50)) (email (string-ascii 100)))
+  (let
+    (
+      (caller tx-sender)
+      (safe-username (as-max-len? username u50))
+      (safe-email (as-max-len? email u100))
+    )
+    (asserts! (is-none (map-get? users caller)) ERR-USER-EXISTS)
+    (asserts! (is-some safe-username) ERR-INVALID-USERNAME)
+    (asserts! (is-some safe-email) ERR-INVALID-EMAIL)
+    (asserts! (validate-username (unwrap-panic safe-username)) ERR-INVALID-USERNAME)
+    (asserts! (validate-email (unwrap-panic safe-email)) ERR-INVALID-EMAIL)
+    (asserts! (is-none (map-get? taken-usernames (unwrap-panic safe-username))) ERR-USERNAME-TAKEN)
+    
+    ;; Set the user data
+    (map-set users caller
+      {
+        username: (unwrap-panic safe-username),
+        email: (unwrap-panic safe-email),
+        profile-image: none
+      }
+    )
+    ;; Mark username as taken
+    (map-set taken-usernames (unwrap-panic safe-username) true)
+    (var-set user-count (+ (var-get user-count) u1))
+    (ok true)
+  )
+)
+
+;; Function to check if username is available
+(define-read-only (is-username-available (username (string-ascii 50)))
+  (let
+    ((safe-username (as-max-len? username u50)))
+    (if (and
+          (is-some safe-username)
+          (validate-username (unwrap-panic safe-username)))
+      (ok (is-none (map-get? taken-usernames (unwrap-panic safe-username))))
+      ERR-INVALID-USERNAME
+    )
+  )
+)
+
+(define-private (check-username-match (username (string-ascii 50)) (user principal) (found bool))
+  (if found
+    found
+    (let ((user-info (unwrap-panic (map-get? users user))))
+      (is-eq (get username user-info) username)
+    )
+  )
+)
+
+(define-public (update-profile (new-username (string-ascii 50)) (new-email (string-ascii 100)))
+  (let
+    (
+      (caller tx-sender)
+      (safe-username (as-max-len? new-username u50))
+      (safe-email (as-max-len? new-email u100))
+      (current-user (map-get? users caller))
+    )
+    (asserts! (is-some current-user) ERR-USER-NOT-FOUND)
+    (asserts! (is-some safe-username) ERR-INVALID-USERNAME)
+    (asserts! (is-some safe-email) ERR-INVALID-EMAIL)
+    (asserts! (validate-username (unwrap-panic safe-username)) ERR-INVALID-USERNAME)
+    (asserts! (validate-email (unwrap-panic safe-email)) ERR-INVALID-EMAIL)
+    
+    ;; Only check availability if username is different
+    (if (not (is-eq (get username (unwrap-panic current-user)) (unwrap-panic safe-username)))
+      (asserts! (is-none (map-get? taken-usernames (unwrap-panic safe-username))) ERR-USERNAME-TAKEN)
+      true
+    )
+    
+    ;; Remove old username from taken list
+    (map-delete taken-usernames (get username (unwrap-panic current-user)))
+    ;; Add new username to taken list
+    (map-set taken-usernames (unwrap-panic safe-username) true)
+    
+    (map-set users caller
+      (merge (unwrap-panic current-user)
+        {
+          username: (unwrap-panic safe-username),
+          email: (unwrap-panic safe-email)
+        }
+      )
+    )
+    (ok true)
+  )
+)
+


### PR DESCRIPTION


##  Pull Request: Add Registration, Username Availability, and Profile Update Logic to `sBTC-dUser`

### 📌 Overview

This pull request expands the `sBTC-dUser` smart contract with core identity management functionality, enabling **decentralized user registration, profile updating, and real-time username availability checks**. These additions empower users to claim and manage unique Web3 usernames, emails, and identities directly on-chain—without relying on centralized services.

---

### ✅ What's Included

#### 1. **User Registration**

```clojure
(register-user username email)
```

* Registers a new user tied to the caller’s `principal`
* Validates:

  * Username length: `3–50 ASCII characters`
  * Email format: must include `'@'` and `'.'`
  * Username uniqueness
* Stores the user's `username`, `email`, and sets `profile-image` to `none`
* Increments total `user-count`

#### 2. **Username Availability Check**

```clojure
(is-username-available username)
```

* Validates format and length
* Checks against `taken-usernames` map to ensure global uniqueness
* Returns `true` if available, or descriptive error if invalid

#### 3. **Profile Update**

```clojure
(update-profile new-username new-email)
```

* Allows a registered user to update their username and/or email
* If username changes:

  * Checks if the new one is available
  * Releases the old one and reserves the new one
* Ensures all input validation (format, length, uniqueness) is enforced
* Merges new data into the user's on-chain profile

---

### 🛡️ Validation & Safety

* Utilizes `as-max-len?` and pattern checks for safe bounded string handling
* Uses `unwrap-panic` **only after validation** to ensure safe map/set operations
* All changes are permissioned to `tx-sender` only

---

### 🗃️ Storage Maps Updated

| Map Name          | Purpose                                  |
| ----------------- | ---------------------------------------- |
| `users`           | Stores per-user profile info             |
| `taken-usernames` | Tracks which usernames have been claimed |
| `user-count`      | Tracks total number of registered users  |

---

### 📖 Error Codes

| Error Code             | Meaning                               |
| ---------------------- | ------------------------------------- |
| `ERR-USER-EXISTS`      | Caller already registered a profile   |
| `ERR-INVALID-USERNAME` | Fails length or format requirements   |
| `ERR-INVALID-EMAIL`    | Fails length or lacks '@' and '.'     |
| `ERR-USERNAME-TAKEN`   | Attempting to use a reserved username |
| `ERR-USER-NOT-FOUND`   | Caller has no registered profile      |

---
